### PR TITLE
Fix typo in ODFriction

### DIFF
--- a/src/FrictionProviders.jl
+++ b/src/FrictionProviders.jl
@@ -21,7 +21,7 @@ export LDFAFriction
 export AceLDFA
 export CubeLDFA
 export SciKitLDFA
-export ODFrictio
+export ODFriction
 export SchNetODF
 export ACEdsODF
 


### PR DESCRIPTION
Wasn't able to load ACE ODF models due to a typo in export statement. 